### PR TITLE
Use bash as shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/sh
+SHELL = /bin/bash
 
 # directories and source code lists
 ROOT = .


### PR DESCRIPTION
Play nice if /bin/sh is not bash (like on Ubuntu, where it is linked to /bin/dash)